### PR TITLE
check ref before measuring

### DIFF
--- a/components/SectionList.js
+++ b/components/SectionList.js
@@ -71,7 +71,9 @@ export default class SectionList extends Component {
 
   fixSectionItemMeasure() {
     const sectionItem = this.refs.sectionItem0;
-
+    if (!sectionItem) {
+      return;
+    }
     this.measureTimer = setTimeout(() => {
       sectionItem.measure((x, y, width, height, pageX, pageY) => {
         //console.log([x, y, width, height, pageX, pageY]);


### PR DESCRIPTION
I added a quick guard clause to stop it trying to measure a ref which does not exist